### PR TITLE
add game over scene

### DIFF
--- a/client/src/scene/game_over_scene.cpp
+++ b/client/src/scene/game_over_scene.cpp
@@ -1,15 +1,45 @@
 #include "game_over_scene.h"
 
+#include "client_asset_manager.h"
 #include "client_context.h"
 #include "constants/input_constants.h"
 #include "constants/ui_constants.h"
 #include "engine/input.h"
 #include "engine/render/color.h"
 #include "engine/ui/layouts.h"
+#include "ui/menu_background.h"
 
 namespace client {
+
+namespace {
+
+ui::MenuPointerConfig GameOverPointerConfig() {
+  return ui::MenuPointerConfig{constants::ui::kMenuPointerFramePrefix,
+                               constants::ui::kMenuPointerFrameExtension,
+                               constants::ui::MainMenu::kPointerFrameCount,
+                               constants::ui::MainMenu::kPointerFrameDuration,
+                               constants::ui::MainMenu::kPointerHeightFactor,
+                               60.0f, // Increased spacing to avoid overlap
+                               constants::ui::MainMenu::kPointerScaleFactor};
+}
+
+}  // namespace
+
 GameOverScene::GameOverScene(ClientContext& context, const Stats& stats)
-    : context_(context), stats_(stats) {
+    : context_(context),
+      stats_(stats),
+      menu_effects_(context, GameOverPointerConfig(),
+                    constants::ui::kMenuHoverSfxPath,
+                    constants::ui::kMenuClickSfxPath) {
+  auto& renderer = context_.Renderer();
+  auto& assets = context_.Assets();
+
+  assets.LoadFont(constants::ui::kTitleFont, constants::ui::kTitleFontPath);
+  assets.LoadFont(constants::ui::kBodyFont, constants::ui::kBodyFontPath);
+  renderer.SetFont(std::string(constants::ui::kBodyFont));
+
+  menu_effects_.Load();
+
   auto root =
       std::make_shared<engine::ui::StackContainer>(engine::ui::Axis::kVertical);
   root->Layout().size.width = engine::ui::LayoutValue::Percent(1.0f);
@@ -23,10 +53,11 @@ GameOverScene::GameOverScene(ClientContext& context, const Stats& stats)
                            engine::ui::VerticalAlignment::kCenter});
 
   title_ = std::make_shared<engine::ui::TextElement>(
-      "GAME OVER",
+      "MISSION FAILED",
       engine::ui::FontSize::RelativeWidth(
           constants::ui::GameOver::kTitleFontScale),
-      constants::ui::GameOver::kTitleColor);
+      constants::ui::GameOver::kSelectedColor);
+  title_->SetFont(std::string(constants::ui::kTitleFont));
 
   score_text_ = std::make_shared<engine::ui::TextElement>(
       "Final Score: " + std::to_string(stats_.score),
@@ -40,11 +71,20 @@ GameOverScene::GameOverScene(ClientContext& context, const Stats& stats)
           constants::ui::GameOver::kWaveFontScale),
       constants::ui::GameOver::kNormalColor);
 
-  menu_main_exit_ = std::make_shared<engine::ui::TextElement>(
-      "Return to Main Menu",
-      engine::ui::FontSize::RelativeWidth(
-          constants::ui::GameOver::kMenuFontScale),
-      constants::ui::GameOver::kSelectedColor);
+  menu_main_exit_button_ = std::make_shared<engine::ui::Button>(
+      engine::math::Vector2f{0.0f, 0.0f},
+      engine::math::Vector2f{250.0f,
+                             constants::ui::MainMenu::kButtonHeight},
+      "Return to Menu",
+      menu_effects_.WrapClick([this]() { context_.OnQuitToMenu(); }));
+
+  ui_elements_.push_back(menu_main_exit_button_);
+
+  const auto transparent = engine::render::Color::FromBytes(0, 0, 0, 0);
+  const auto white = engine::render::Color::White();
+  menu_main_exit_button_->SetColors(transparent, transparent, transparent);
+  menu_main_exit_button_->SetTextColor(white);
+  menu_main_exit_button_->SetTextScale(constants::ui::MainMenu::kButtonTextScale);
 
   root->AddChild(title_);
   root->AddChild(score_text_);
@@ -55,29 +95,64 @@ GameOverScene::GameOverScene(ClientContext& context, const Stats& stats)
       engine::ui::LayoutValue::Pixels(constants::ui::GameOver::kSpacerHeight);
   root->AddChild(spacer);
 
-  root->AddChild(menu_main_exit_);
+  auto button_slot = std::make_shared<engine::ui::BoxElement>();
+  button_slot->Layout().size.width =
+      engine::ui::LayoutValue::Pixels(250.0f);
+  button_slot->Layout().size.height =
+      engine::ui::LayoutValue::Pixels(constants::ui::MainMenu::kButtonHeight);
+  button_slot->SetLayoutCallback([this](const engine::math::RectF& rect) {
+    menu_main_exit_button_->SetPosition({rect.top_left_x_, rect.top_left_y_});
+    menu_main_exit_button_->SetSize({rect.width_, rect.height_});
+  });
+
+  root->AddChild(button_slot);
 
   canvas_.SetRoot(root);
-  UpdateMenuVisuals();
 }
 
-void GameOverScene::Update(engine::time::TimeDelta /*dt*/) {
-  auto& input = context_.Input();
+void GameOverScene::Update(engine::time::TimeDelta dt) {
+  context_.MenuBackground().Update(dt);
 
+  auto& input = context_.Input();
+  menu_effects_.Update(dt, input, ui_elements_);
+
+  for (auto& elem : ui_elements_) {
+    elem->Update(dt, input);
+  }
+
+  // Backup key to quit
   if (input.IsActionActive(std::string(constants::input::kActionConfirm))) {
-    context_.OnQuitToMenu();
+     // Optional: Trigger button click or just quit
+     // context_.OnQuitToMenu();
   }
 }
 
-void GameOverScene::UpdateMenuVisuals() {
-  menu_main_exit_->SetColor(constants::ui::GameOver::kSelectedColor);
+void GameOverScene::Draw(engine::render::Renderer2D& renderer) {
+  DrawBackground(renderer);
+  DrawForeground(renderer);
 }
 
-void GameOverScene::Draw(engine::render::Renderer2D& renderer) {
+void GameOverScene::DrawBackground(engine::render::Renderer2D& renderer) {
+  static_cast<void>(renderer);
+  context_.MenuBackground().Draw(context_.RenderSize());
+}
+
+void GameOverScene::DrawForeground(engine::render::Renderer2D& renderer) {
+  renderer.SetFont(std::string(constants::ui::kBodyFont));
+  LayoutUi(renderer);
+  canvas_.Draw(renderer);
+
+  for (auto& elem : ui_elements_) {
+    elem->Draw(renderer);
+  }
+  menu_effects_.DrawPointers(renderer, ui_elements_);
+}
+
+void GameOverScene::LayoutUi(engine::render::Renderer2D& renderer) {
   const auto render_size = context_.RenderSize();
   canvas_.SetViewportSize(
       {static_cast<float>(render_size.x), static_cast<float>(render_size.y)});
-  canvas_.LayoutAndDraw(renderer);
+  canvas_.Layout(renderer);
 }
 
 }  // namespace client

--- a/client/src/scene/game_over_scene.cpp
+++ b/client/src/scene/game_over_scene.cpp
@@ -19,7 +19,7 @@ ui::MenuPointerConfig GameOverPointerConfig() {
                                constants::ui::MainMenu::kPointerFrameCount,
                                constants::ui::MainMenu::kPointerFrameDuration,
                                constants::ui::MainMenu::kPointerHeightFactor,
-                               60.0f, // Increased spacing to avoid overlap
+                               60.0f,
                                constants::ui::MainMenu::kPointerScaleFactor};
 }
 
@@ -73,8 +73,7 @@ GameOverScene::GameOverScene(ClientContext& context, const Stats& stats)
 
   menu_main_exit_button_ = std::make_shared<engine::ui::Button>(
       engine::math::Vector2f{0.0f, 0.0f},
-      engine::math::Vector2f{250.0f,
-                             constants::ui::MainMenu::kButtonHeight},
+      engine::math::Vector2f{250.0f, constants::ui::MainMenu::kButtonHeight},
       "Return to Menu",
       menu_effects_.WrapClick([this]() { context_.OnQuitToMenu(); }));
 
@@ -84,7 +83,8 @@ GameOverScene::GameOverScene(ClientContext& context, const Stats& stats)
   const auto white = engine::render::Color::White();
   menu_main_exit_button_->SetColors(transparent, transparent, transparent);
   menu_main_exit_button_->SetTextColor(white);
-  menu_main_exit_button_->SetTextScale(constants::ui::MainMenu::kButtonTextScale);
+  menu_main_exit_button_->SetTextScale(
+      constants::ui::MainMenu::kButtonTextScale);
 
   root->AddChild(title_);
   root->AddChild(score_text_);
@@ -96,8 +96,7 @@ GameOverScene::GameOverScene(ClientContext& context, const Stats& stats)
   root->AddChild(spacer);
 
   auto button_slot = std::make_shared<engine::ui::BoxElement>();
-  button_slot->Layout().size.width =
-      engine::ui::LayoutValue::Pixels(250.0f);
+  button_slot->Layout().size.width = engine::ui::LayoutValue::Pixels(250.0f);
   button_slot->Layout().size.height =
       engine::ui::LayoutValue::Pixels(constants::ui::MainMenu::kButtonHeight);
   button_slot->SetLayoutCallback([this](const engine::math::RectF& rect) {
@@ -120,10 +119,8 @@ void GameOverScene::Update(engine::time::TimeDelta dt) {
     elem->Update(dt, input);
   }
 
-  // Backup key to quit
   if (input.IsActionActive(std::string(constants::input::kActionConfirm))) {
-     // Optional: Trigger button click or just quit
-     // context_.OnQuitToMenu();
+    context_.OnQuitToMenu();
   }
 }
 

--- a/client/src/scene/game_over_scene.h
+++ b/client/src/scene/game_over_scene.h
@@ -3,10 +3,13 @@
 
 #include <cstdint>
 #include <memory>
+#include <vector>
 
-#include "scene.h"
+#include "engine/ui/button.h"
 #include "engine/ui/canvas.h"
 #include "engine/ui/text.h"
+#include "scene.h"
+#include "ui/menu_effects.h"
 
 namespace client {
 
@@ -24,8 +27,11 @@ class GameOverScene : public Scene {
   void Update(engine::time::TimeDelta dt) override;
   void Draw(engine::render::Renderer2D& renderer) override;
 
+  void DrawBackground(engine::render::Renderer2D& renderer) override;
+  void DrawForeground(engine::render::Renderer2D& renderer) override;
+
  private:
-  void UpdateMenuVisuals();
+  void LayoutUi(engine::render::Renderer2D& renderer);
 
   ClientContext& context_;
   Stats stats_;
@@ -33,7 +39,9 @@ class GameOverScene : public Scene {
   std::shared_ptr<engine::ui::TextElement> title_;
   std::shared_ptr<engine::ui::TextElement> score_text_;
   std::shared_ptr<engine::ui::TextElement> wave_level_text_;
-  std::shared_ptr<engine::ui::TextElement> menu_main_exit_;
+  std::shared_ptr<engine::ui::Button> menu_main_exit_button_;
+  std::vector<std::shared_ptr<engine::ui::Button>> ui_elements_;
+  ui::MenuEffects menu_effects_;
 };
 
 }  // namespace client

--- a/client/src/scene/key_bindings_scene.cpp
+++ b/client/src/scene/key_bindings_scene.cpp
@@ -156,17 +156,14 @@ KeyBindingsScene::KeyBindingsScene(ClientContext& context)
         engine::ui::HorizontalAlignment::kCenter;
     slot->Layout().size.height =
         engine::ui::LayoutValue::Pixels(row_slot_height);
-    // Ensure the slot is wide enough for the button
     slot->Layout().size.width =
         engine::ui::LayoutValue::Pixels(kRowButtonWidth);
 
     slot->SetLayoutCallback([this, i](const engine::math::RectF& rect) {
       auto& row = rows_[i];
       row.row_rect = rect;
-      // Button fills the slot width (which we set to kRowButtonWidth)
       const float base_width = kRowButtonWidth;
       const float base_height = constants::ui::OptionsMenu::kButtonHeight;
-      // Center in slot
       const float base_x = rect.top_left_x_ + (rect.width_ - base_width) * 0.5f;
       const float base_y =
           rect.top_left_y_ + constants::ui::OptionsMenu::kButtonSlotInset;
@@ -225,16 +222,13 @@ void KeyBindingsScene::Update(engine::time::TimeDelta dt) {
   auto& input = context_.Input();
 
   if (is_binding_) {
-    // Check for any key press
     auto bindable_keys = BindableKeys();
     for (const auto key : bindable_keys) {
       if (input.IsKeyDown(key)) {
-        // Check for cancel (Escape)
         if (key == engine::input::Key::kEscape) {
           is_binding_ = false;
         } else {
           auto result = context_.UpdateKeyBinding(binding_action_, key);
-          // We could show result.message here if we had a status text
           is_binding_ = false;
         }
         break;
@@ -369,8 +363,6 @@ void KeyBindingsScene::HandleRebind(GameAction action) {
   binding_action_ = action;
 }
 
-void KeyBindingsScene::RefreshButtons() {
-  // Buttons are refreshed in DrawRows
-}
+void KeyBindingsScene::RefreshButtons() {}
 
 }  // namespace client


### PR DESCRIPTION
- **feat(profile): update profile scene decoration to match options menu style**
- **feat(application): update ToString function to include key bindings state for better state representation**
- **feat(client_context.h): add virtual methods for opening and closing key bindings menu to enhance user interface options**
- **feat(client_state.h): add kKeyBindings to ClientState enum to support key binding settings in the client**
- **feat(options_menu_scene.cpp): add functionality to the Keyboard button to open key bindings for better user experience**
- **feat(scene_manager): add key bindings scene and related transitions to enhance user experience**
- **feat: adding new keybind scene**
- **fix(keybindings.json): update keybindings for MoveDown and MoveUp to improve gameplay experience**
- **feat(game_over_scene): enhance game over scene with new UI elements and effects**
